### PR TITLE
Added virtualenv info to prompt.

### DIFF
--- a/modules/prompt/functions/prompt_paradox_setup
+++ b/modules/prompt/functions/prompt_paradox_setup
@@ -8,6 +8,7 @@
 #   Isaac Wolkerstorfer <i@agnoster.net>
 #   Jeff Sandberg <paradox460@gmail.com>
 #   Sorin Ionescu <sorin.ionescu@gmail.com>
+#   Milind Shakya <sh.milind@gmail.com>
 #
 # Screenshots:
 #   http://i.imgur.com/0XIWX.png
@@ -50,6 +51,10 @@ function prompt_paradox_build_prompt {
 
   if [[ -n "$git_info" ]]; then
     prompt_paradox_start_segment green black '${(e)git_info[ref]}${(e)git_info[status]}'
+  fi
+  
+  if [[ -n "${python_info}" ]]; then
+    prompt_paradox_start_segment yellow black '${python_info[ref]}${python_info[virtualenv]}'
   fi
 
   prompt_paradox_end_segment
@@ -95,6 +100,11 @@ function prompt_paradox_precmd {
   # Get Git repository information.
   if (( $+functions[git-info] )); then
     git-info
+  fi
+  
+  # Get Virtual env info
+  if (( $+functions[python-info] )); then
+    python-info
   fi
 
   # Calculate and print the elapsed time.
@@ -142,6 +152,9 @@ function prompt_paradox_setup {
   zstyle ':prezto:module:git:info:keys' format \
     'ref' '$(coalesce "%b" "%p" "%c")' \
     'status' '%s%D%A%B%S%a%d%m%r%U%u'
+  
+  # Set python-info parameters.
+  zstyle ':prezto:module:python:info:virtualenv' format '%F{black}py:%v%f'
 
   # Define prompts.
   PROMPT='


### PR DESCRIPTION
Added virtualenv info to paradox prompt.

whitespace

Updated authors list in paradox prompt file

Changed virtualenv color to yellow to better distinguish directory segment, which was also blue before

Fixed bug when deactivating virtualenv, it left an empty segment. Now deactivating removes entire virtualenv segment.

Formatting
